### PR TITLE
Fix for #37: removed forgotten debug prints

### DIFF
--- a/main/java/com/yyon/grapplinghook/grapplemod.java
+++ b/main/java/com/yyon/grapplinghook/grapplemod.java
@@ -361,7 +361,7 @@ public class grapplemod {
 			}
 		}
 		
-		System.out.println(blockpos);
+//		System.out.println(blockpos);
 		
 		grappleController control = null;
 		if (id == GRAPPLEID) {
@@ -398,11 +398,11 @@ public class grapplemod {
 				}
 			}
 			if (!created) {
-				System.out.println("Couldn't create");
+//				System.out.println("Couldn't create");
 				grapplemod.removesubarrow(arrowid);
 			}
 		} else if (id == AIRID) {
-			System.out.println("AIR FRICTION CONTROLLER");
+//			System.out.println("AIR FRICTION CONTROLLER");
 			control = new airfrictionController(arrowid, entityid, world, pos, maxlen, id);
 		}
 		if (blockpos != null && control != null) {


### PR DESCRIPTION
The forgotten debug prints are causing noticeable lag in single player and assuming your mod is actively used by players on server will generate bad lag spikes on servers as they are generated per player whenever hook is active.
