### PR TITLE
Prevent tick from running when shootingEntity is null

### DIFF
--- a/main/java/com/yyon/grapplinghook/entities/grapplehook/GrapplehookEntity.java
+++ b/main/java/com/yyon/grapplinghook/entities/grapplehook/GrapplehookEntity.java
@@ -156,6 +156,7 @@ public class GrapplehookEntity extends ProjectileItemEntity implements IEntityAd
 	public void tick() {
 		if (this.shootingEntityID == 0 || this.shootingEntity == null) { // removes ghost grappling hooks
 			this.remove();
+			return;
 		}
 		
 		if (this.firstAttach) {
@@ -232,7 +233,6 @@ public class GrapplehookEntity extends ProjectileItemEntity implements IEntityAd
 		
 		// magnet attraction
 		if (!this.attached && this.customization.attract && Vec.positionVec(this).sub(Vec.positionVec(this.shootingEntity)).length() > this.customization.attractradius) {
-	    	if (this.shootingEntity == null) {return;}
 	    	if (!this.foundBlock) {
 	    		if (!this.level.isClientSide) {
 	    			Vec playerpos = Vec.positionVec(this.shootingEntity);


### PR DESCRIPTION
Ghost grappling hooks [shootingEntity==null] can tick under some circumstances, at least on the client side. This patch make sure the tick actually stops when this is detected rather than simply removing and continuing running the tick. The crash I saw was in line 234, in Vec.positionVec(this.shootingEntity). I removed a redundant null check after this point too since if it's null before this point it crashes.