### PR TITLE
Change non-matching license

### DIFF
--- a/main/resources/META-INF/mods.toml
+++ b/main/resources/META-INF/mods.toml
@@ -3,7 +3,7 @@ modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
 loaderVersion="${loader_version_range}" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 
-license="All rights reserved"
+license="GPL-3.0"
 
 [[mods]] #mandatory
 # The modid of the mod


### PR DESCRIPTION
This PR changes the license at the mods.toml to match the repository's, as it was under ARR when in CurseForge and this repo states it's under GPL-3.0.