### PR TITLE
Try to fix ConcurrentModificationException (#107)

### DIFF
--- a/src/main/java/com/yyon/grapplinghook/client/ClientSetup.java
+++ b/src/main/java/com/yyon/grapplinghook/client/ClientSetup.java
@@ -62,7 +62,9 @@ public class ClientSetup {
 	@SubscribeEvent
 	public static void clientSetup(final FMLClientSetupEvent event) {
 	    instance = new ClientSetup();
-	    instance.onClientSetup();
+            // The onclientSetup method calls ItemProperties::register which is
+            // not thread-safe, so enqueue it.
+	    event.enqueueWork(instance::onClientSetup);
 	}
 	
 	private static class GrapplehookEntityRenderFactory implements EntityRendererProvider<GrapplehookEntity> {


### PR DESCRIPTION
The `ItemProperties::register` method is not-thread safe, potentially leading to `ConcurrentModificationException` being thrown on startup. This MR attempts to fix that by enqueuing the `ClientSetup::onClientSetup` method, based on [a similar issue and fix in another mod](https://github.com/Infamous-Misadventures/Dungeons-Mobs/issues/182).

Potentially fixes issue #107. It's hard to test whether the fix actually works because concurrency bugs are a pain to reproduce.