### PR TITLE
Unhook players when they enter Spectator Mode - Fixes #71

### DIFF
--- a/src/main/java/com/yyon/grapplinghook/client/ClientEventHandlers.java
+++ b/src/main/java/com/yyon/grapplinghook/client/ClientEventHandlers.java
@@ -14,9 +14,12 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
+import net.minecraftforge.client.event.ClientPlayerChangeGameTypeEvent;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent.LoggingOut;
 import net.minecraftforge.client.event.InputEvent.Key;
 import net.minecraftforge.client.event.MovementInputUpdateEvent;
@@ -26,6 +29,8 @@ import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.level.BlockEvent.BreakEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import java.util.UUID;
 
 public class ClientEventHandlers {
 	public static ClientEventHandlers instance = null;
@@ -188,6 +193,27 @@ public class ClientEventHandlers {
 		
 		if (currentCameraTilt != 0) {
 		    event.setRoll(event.getRoll() + currentCameraTilt*GrappleConfig.getClientConf().camera.wallrun_camera_tilt_degrees);
+		}
+	}
+
+	@SubscribeEvent
+	public void onGameModeChange(ClientPlayerChangeGameTypeEvent event) {
+		Level level = Minecraft.getInstance().level;
+
+		if(level == null) return;
+
+		if(event.getNewGameType() == GameType.SPECTATOR) {
+			UUID profile = event.getInfo().getProfile().getId();
+			Player p = level.getPlayerByUUID(profile);
+
+			if (p == null) return;
+
+			int id = p.getId();
+
+			GrappleController controller = ClientControllerManager.controllers.get(id);
+
+			if (controller != null)
+				controller.unattach(false);
 		}
 	}
 

--- a/src/main/java/com/yyon/grapplinghook/controllers/GrappleController.java
+++ b/src/main/java/com/yyon/grapplinghook/controllers/GrappleController.java
@@ -11,11 +11,14 @@ import com.yyon.grapplinghook.utils.GrappleCustomization;
 import com.yyon.grapplinghook.utils.GrapplemodUtils;
 import com.yyon.grapplinghook.utils.Vec;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.PlayerInfo;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SoundType;
@@ -93,16 +96,27 @@ public class GrappleController {
 			ClientProxyInterface.proxy.updateRocketRegen(custom.rocket_active_time, custom.rocket_refuel_ratio);
 		}
 	}
-	
+
+
 	public void unattach() {
-		if (ClientProxyInterface.proxy.unregisterController(this.entityId) != null) {
-			this.attached = false;
-			
-			if (this.controllerId != GrapplemodUtils.AIRID) {
-				CommonSetup.network.sendToServer(new GrappleEndMessage(this.entityId, this.grapplehookEntityIds));
-				ClientProxyInterface.proxy.createControl(GrapplemodUtils.AIRID, -1, this.entityId, this.entity.level(), new Vec(0,0,0), null, this.custom);
-			}
-		}
+		// old behaviour was always true to trigger air friction - retain this unless
+		// there's a good reason to change it.
+		this.unattach(true);
+	}
+	
+	public void unattach(boolean allowFollowupControllers) {
+		if (ClientProxyInterface.proxy.unregisterController(this.entityId) == null)
+			return;
+
+		this.attached = false;
+
+		if (this.controllerId == GrapplemodUtils.AIRID)
+			return;
+
+		CommonSetup.network.sendToServer(new GrappleEndMessage(this.entityId, this.grapplehookEntityIds));
+
+		if(allowFollowupControllers)
+			ClientProxyInterface.proxy.createControl(GrapplemodUtils.AIRID, -1, this.entityId, this.entity.level(), new Vec(0,0,0), null, this.custom);
 	}
 	
 	


### PR DESCRIPTION
As the title says.

I would've implemented it without having to add a parameter to unattach, however, that would've needed mixins due to where Forge triggers the gamemode event. This seems to work though and doesn't break old functionality.

Still a recent fix so it may need more testing buuuuut, it seems to work just fine.